### PR TITLE
Add Benchmarks and Miscellaneous Improvements

### DIFF
--- a/info.go
+++ b/info.go
@@ -166,3 +166,16 @@ func (e *Explorer) MerkleProof(id types.ElementID) ([]types.Hash256, error) {
 	}
 	return e.hs.MerkleProof(index)
 }
+
+// Size returns the combined size in bytes of the SQL store and the hash store.
+func (e *Explorer) Size() (uint64, error) {
+	dbSize, err := e.db.Size()
+	if err != nil {
+		return 0, err
+	}
+	hsSize, err := e.hs.Size()
+	if err != nil {
+		return 0, err
+	}
+	return dbSize + hsSize, nil
+}

--- a/internal/explorerutil/hashstore.go
+++ b/internal/explorerutil/hashstore.go
@@ -57,6 +57,19 @@ func (hs *HashStore) ModifyLeaf(elem types.StateElement) error {
 	return nil
 }
 
+// Size implements explorer.HashStore.
+func (hs *HashStore) Size() (uint64, error) {
+	var size uint64
+	for _, f := range hs.hashFiles {
+		stat, err := f.Stat()
+		if err != nil {
+			return 0, err
+		}
+		size += uint64(stat.Size())
+	}
+	return size, nil
+}
+
 // Commit implements explorer.HashStore.
 func (hs *HashStore) Commit() error {
 	for _, f := range hs.hashFiles {

--- a/internal/explorerutil/store.go
+++ b/internal/explorerutil/store.go
@@ -95,6 +95,13 @@ func (s *SQLiteStore) Commit() (err error) {
 	return
 }
 
+// Size implements explorer.Store.
+func (s *SQLiteStore) Size() (uint64, error) {
+	var size uint64
+	s.txErr = s.tx.QueryRow(`SELECT (page_count - freelist_count) * page_size as size FROM pragma_page_count(), pragma_freelist_count(), pragma_page_size();`).Scan(&size)
+	return size, s.txErr
+}
+
 // SiacoinElement implements explorer.Store.
 func (s *SQLiteStore) SiacoinElement(id types.ElementID) (sce types.SiacoinElement, err error) {
 	err = s.queryRow(&sce, `SELECT data FROM elements WHERE id=? AND type=?`, encode(id), "siacoin")
@@ -190,16 +197,19 @@ func (s *SQLiteStore) State(index types.ChainIndex) (context consensus.State, er
 
 // AddSiacoinElement implements explorer.Store.
 func (s *SQLiteStore) AddSiacoinElement(sce types.SiacoinElement) {
+	sce.MerkleProof = nil
 	s.execStatement(`INSERT INTO elements(id, type, data) VALUES(?, ?, ?)`, encode(sce.ID), "siacoin", encode(sce))
 }
 
 // AddSiafundElement implements explorer.Store.
 func (s *SQLiteStore) AddSiafundElement(sfe types.SiafundElement) {
+	sfe.MerkleProof = nil
 	s.execStatement(`INSERT INTO elements(id, type, data) VALUES(?, ?, ?)`, encode(sfe.ID), "siafund", encode(sfe))
 }
 
 // AddFileContractElement implements explorer.Store.
 func (s *SQLiteStore) AddFileContractElement(fce types.FileContractElement) {
+	fce.MerkleProof = nil
 	s.execStatement(`INSERT INTO elements(id, type, data) VALUES(?, ?, ?)`, encode(fce.ID), "contract", encode(fce))
 }
 


### PR DESCRIPTION
- The SQLiteStore no longer stores merkle proofs of elements because we now have the HashStore to retrieve proofs in a more space efficient manner
   - Fixed tests to account for this 
-  Adds benchmarks for adding blocks, querying elements and their proofs
- Add Size function to interfaces of both stores
